### PR TITLE
DOTOLI-80 prettier 마이그레이션

### DIFF
--- a/packages/prettier-config/index.js
+++ b/packages/prettier-config/index.js
@@ -1,4 +1,4 @@
-module.exports = {
+const config = {
   semi: true,
   useTabs: false,
   tabWidth: 2,
@@ -8,3 +8,5 @@ module.exports = {
   plugins: ['prettier-plugin-tailwindcss'],
   tailwindFunctions: ['clsx'],
 };
+
+export default config;

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -2,6 +2,7 @@
   "name": "@dotoli/prettier-config",
   "version": "0.0.0",
   "license": "MIT",
+  "type": "module",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
일단 구두로 여쭤봤던 prettier 세팅 부분은 정상적으로 동작하는 걸로 확인됐습니다!
(설정 바꾸고 reload를 해야 적용 되는거였군요...)
prettier 버전은 최신버전 사용하고 있어서 버전 업그레이드는 진행하지 않고 파일 형식만 module로 변경했습니다.
컨벤션 상 named exports를 사용하는 게 맞으나 prettier 문서 상 default exports를 사용하게 되어있어서 불가피하게 사용했습니다.

ref. https://prettier.io/docs/configuration